### PR TITLE
exit(1) on disconnect

### DIFF
--- a/src/SocketServer.php
+++ b/src/SocketServer.php
@@ -90,7 +90,7 @@ class SocketServer extends AppServer
         }
 
         $this->getLogger()->debug('Socket Mode connection closed');
-        exit();
+        exit(1);
     }
 
     /**


### PR DESCRIPTION
If an exception occurs or the connection breaks, I would like the server to exit with code `1` to indicate that something unexpected and bad happened.  (This is particularly useful when running in a Docker container.)